### PR TITLE
Update runfret.sh

### DIFF
--- a/executables/runfret.sh
+++ b/executables/runfret.sh
@@ -1,11 +1,6 @@
 
 echo "running pre-compiled FRET"
 
-FRET_HOME=
-
-NUSMV_HOME=
-
-
 export PATH=$PATH:$NUSMV_HOME:$FRET_HOME:$FRET_HOME/resources/app/tools/LTLSIM/ltlsim-core/simulator/
 
 $FRET_HOME/FRET


### PR DESCRIPTION
These lines blow away any FRET_HOME or NUSMV_HOME variables set in the environment making this file impossible to execute.