### PR TITLE
Update ltlsim_smvutils.c

### DIFF
--- a/tools/LTLSIM/ltlsim-core/simulator/ltlsim_smvutils.c
+++ b/tools/LTLSIM/ltlsim-core/simulator/ltlsim_smvutils.c
@@ -33,7 +33,7 @@ int checkNuSMVInstallation(bool doPrint) {
 #ifdef WINDOWS
     fp = popen("nusmv.exe -h 2>&1", "r");
 #else
-    fp = popen("nusmv -h 2>&1", "r");
+    fp = popen("NuSMV -h 2>&1", "r");
 #endif
 
     if (fp == NULL) {


### PR DESCRIPTION
When NuSMV is downloaded, the file in the folder bin is "NuSMV", so it fails to find "nusmv" after including that folder in the PATH variable. Another option could be to look for both NuSMV and nusmv.