### PR TITLE
Update to fix docs import-export links.

### DIFF
--- a/fret-electron/docs/_media/user-interface/tutorial.md
+++ b/fret-electron/docs/_media/user-interface/tutorial.md
@@ -31,8 +31,8 @@ To view and edit the requirements in your project in a tabular form, select the 
 
 Export and import buttons are available for saving/exporting your requirements or importing requirements written by other users in FRET.
 
-More information on how to export is available [here](./export&import/export.md).
-More information on how to import is available [here](./export&import/import.md).
+More information on how to export is available [here](./exportImport/export.md).
+More information on how to import is available [here](./exportImport/import.md).
 
 ## Connecting with external tools
 

--- a/fret-electron/docs/_media/userManual.md
+++ b/fret-electron/docs/_media/userManual.md
@@ -12,8 +12,8 @@ FRET is a framework for the elicitation, specification, formalization and unders
 * [Installing FRET](./installingFRET/installationInstructions.md)
 * [FRET interface](./user-interface/tutorial.md)
 * [Writing requirements](./user-interface/writingReqs.md)
-* [Importing requirements](./user-interface/export&import/import.md)
-* [Exporting requirements](./user-interface/export&import/export.md)
+* [Importing requirements](./user-interface/exportImport/import.md)
+* [Exporting requirements](./user-interface/exportImport/export.md)
 * [Semantics](./semantics/semanticsOverview.md)
 * [Using the simulator](./UsingTheSimulator/ltlsim.md)
 * [Exporting for analysis](./ExportingForAnalysis/analysis.md)
@@ -22,7 +22,7 @@ FRET is a framework for the elicitation, specification, formalization and unders
 
 #### FRET Example Requirements
 
-We provide a set of example requirements that can be directly [imported](./user-interface/export&import/import.md) in FRET  in [FRETDemo.json](../../../tutorialExamples/FRETDemo.json)
+We provide a set of example requirements that can be directly [imported](./user-interface/exportImport/import.md) in FRET  in [FRETDemo.json](../../../tutorialExamples/FRETDemo.json)
 
 ## FRET Team
 


### PR DESCRIPTION
Replace `export&import` with `exportImport`. 